### PR TITLE
making numpy 1.16.1 a minimum requirement, not a hard dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'spacy==2.1.4',
         'scispacy==0.2.2',
         'scikit-learn>=0.20.0',
-        'numpy==1.16.1',
+        'numpy>=1.16.1',
         'sklearn-crfsuite',
         'xmltodict>=0.11.0',
         'joblib>=0.12.5',


### PR DESCRIPTION
type: refactor
files added: none
description: making numpy 1.16.1 a minimum requirement, rather than pinning to that dependency version

The reason for this change is textacy requires numpy == 1.17 (approximately) at least.  So by making 1.16.1 a hard requirement I cannot install both.