### PR TITLE
medaCy 1.0.1

### DIFF
--- a/medacy/__init__.py
+++ b/medacy/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __authors__ = "Andriy Mulyar, Jorge Vargas, Corey Sutphin, Steele Farnsworth, Bobby Best, Bridget T. McInnes"

--- a/medacy/__main__.py
+++ b/medacy/__main__.py
@@ -6,7 +6,9 @@ import datetime as dt
 import importlib
 import json
 import logging
+from sys import argv
 
+from medacy import __version__
 from medacy.data.dataset import Dataset
 from medacy.model.model import Model, DEFAULT_NUM_FOLDS
 from medacy.pipelines import bert_pipeline
@@ -174,7 +176,8 @@ def main():
         logger.addHandler(logging.StreamHandler())
     if args.test_mode:
         logger.setLevel(logging.DEBUG)
-        logging.info("Test mode enabled: logging set to debug")
+        logging.info("Test mode enabled: logging set to debug") 
+    logging.info(f"medaCy v{__version__}\nCommand: python -m medacy {' '.join(argv[1:])}")
     start_time = dt.datetime.now()
     start_timestamp = start_time.strftime('%Y-%m-%d %H:%M:%S')
     logging.info(f'\n\nSTART TIME: {start_timestamp}')

--- a/medacy/tools/json_to_pipeline.py
+++ b/medacy/tools/json_to_pipeline.py
@@ -44,7 +44,7 @@ def json_to_pipeline(json_path):
     :return: a custom pipeline class
     """
 
-    if isinstance(json_path, os.PathLike):
+    if isinstance(json_path, (str, os.PathLike)):
         with open(json_path, 'rb') as f:
             input_json = json.load(f)
     elif isinstance(json_path, dict):

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class PyTest(TestCommand):
 setup(
     name='medacy',
     version=__version__,
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     license='GNU GENERAL PUBLIC LICENSE',
     description='Medical Natural Language Processing (NLP) with spaCy',
     long_description=readme(),
@@ -72,6 +72,11 @@ setup(
         'gensim==3.8.0',
         'en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.2.5/en_core_web_sm-2.2.5.tar.gz'
     ],
+    extras_require={
+        ':python_version == "3.6"': [
+            'dataclasses',
+        ],
+    },
     tests_require=[
         "pytest",
         "pytest-cov",


### PR DESCRIPTION
- Fixed type check that should accept `str` or `os.PathLike`; previously, it only accepted `os.PathLike`
- The log file contains the command that initiated that execution of medaCy.
- Restored Python 3.6 support by installing the `dataclasses` backport when installing in a 3.6 environment.

Closes #197.