### PR TITLE
Set `cuda_device` to `-1` by default.

### DIFF
--- a/medacy/pipelines/lstm_systematic_review_pipeline.py
+++ b/medacy/pipelines/lstm_systematic_review_pipeline.py
@@ -36,7 +36,7 @@ class LstmSystematicReviewPipeline(BasePipeline):
             raise ValueError('This pipeline requires word embeddings.')
 
         self.word_embeddings = kwargs['word_embeddings']
-        self.cuda_device = kwargs['cuda_device']
+        self.cuda_device = kwargs.get('cuda_device', -1)
 
     def get_learner(self):
         learner = BiLstmCrfLearner(self.word_embeddings, self.cuda_device)


### PR DESCRIPTION
Ensures that the CPU is used by default.