### PR TITLE
Fix broken links to guide pages in documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,19 +8,19 @@ of machine learning models for medical information extraction.
 To confront the unique challenges posed by medical text
 medaCy provides interfaces to medical ontologies such as `Metamap <https://metamap.nlm.nih.gov/>`_ allowing their
 integration into text mining workflows. Additional help, examples and tutorials can be found in the examples section
-of the `repository <https://github.com/NLPatVCU/medaCy/tree/master/examples>`_.
+of the `repository <https://github.com/NLPatVCU/medaCy/tree/master/guide>`_.
 
 MedaCy does not officially support non-unix based operating systems (however we have found most functionality works on Windows).
 
 Trained Models
 --------------
-A complete listing of trained models can be found `here <https://github.com/NLPatVCU/medaCy/tree/master/examples#utilizing-pre-trained-ner-models>`_.
+A complete listing of trained models can be found `here <https://github.com/NLPatVCU/medaCy/tree/master/guide#utilizing-pre-trained-ner-models>`_.
 
 
 Datasets
 --------
 MedaCy implements a Dataset functionality that loosely wraps a working directory to manage and version training data.
-See more in the `examples <https://github.com/NLPatVCU/medaCy/tree/master/examples>`_.
+See more in the `examples <https://github.com/NLPatVCU/medaCy/tree/master/guide>`_.
 
 Contents
 --------

--- a/medacy/data/dataset.py
+++ b/medacy/data/dataset.py
@@ -58,7 +58,7 @@ External Datasets
 In the real world, datasets (regardless of domain) are evolving entities. Hence, it is essential to version them.
 A medaCy compatible dataset can be created to facilitate this versioning. A medaCy compatible dataset lives a python
 packages that can be hooked into medaCy or used for any other purpose - it is simply a loose wrapper for this Dataset
-object. Instructions for creating such a dataset can be found `here <https://github.com/NLPatVCU/medaCy/tree/master/examples/guide>`_.
+object. Instructions for creating such a dataset can be found `here <https://github.com/NLPatVCU/medaCy/blob/master/guide/creating_custom_pipeline_from_json.md>`_.
 wrap them.
 """
 


### PR DESCRIPTION
The following hyperlinks in the [documentation](https://medacy.readthedocs.io/en/latest/index.html) return the status code 404 Not Found:

<img width="743" alt="Screenshot 2022-02-06 at 02 44 21" src="https://user-images.githubusercontent.com/65498475/152664900-551800f9-7079-4f04-9a15-3594b7b0ac4e.png">

This PR aims to update all such links, in the documentation and module docstring of `medacy/data/dataset.py`, to the intended (but working) links.